### PR TITLE
Ensure inputs are added to new sessions

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -711,7 +711,7 @@ public class NextLevel: NSObject {
         if let session = self._captureSession {
             self.beginConfiguration()
             self.removeInputs(session: session)
-            self.removeOutputsIfNecessary(session: session)
+            self.removeOutputs(session: session)
             self.commitConfiguration()
         }
 
@@ -930,7 +930,7 @@ extension NextLevel {
         
             // setup preset and mode
             
-            self.removeOutputsIfNecessary(session: session)
+            self.removeUnusedOutputsForCurrentCameraMode(session: session)
             
             switch self.cameraMode {
             case .video:
@@ -1117,7 +1117,7 @@ extension NextLevel {
         
     }
 
-    private func removeOutputs(session: AVCaptureSession) {
+    internal func removeOutputs(session: AVCaptureSession) {
         guard let outputs = session.outputs as? [AVCaptureOutput] else {
             return
         }
@@ -1131,7 +1131,7 @@ extension NextLevel {
         self._photoOutput = nil
     }
 
-    internal func removeOutputsIfNecessary(session: AVCaptureSession) {
+    internal func removeUnusedOutputsForCurrentCameraMode(session: AVCaptureSession) {
         guard let currentOutputs = session.outputs as? [AVCaptureOutput] else {
             return
         }

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -826,7 +826,7 @@ extension NextLevel {
                 
                 self._recordingSession = nil
                 self._captureSession = nil
-            
+                self._currentDevice = nil
             }
         }
     }
@@ -1112,7 +1112,7 @@ extension NextLevel {
                 return true
             }
         }
-        print("NextLevel, couldn't add audio output to session")
+        print("NextLevel, couldn't add photo output to session")
         return false
         
     }

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -1130,31 +1130,43 @@ extension NextLevel {
         self._audioInput = nil
         self._photoOutput = nil
     }
-    
+
     internal func removeOutputsIfNecessary(session: AVCaptureSession) {
+        guard let currentOutputs = session.outputs as? [AVCaptureOutput] else {
+            fatalError("Expected outputs to be an array of AVCaptureOutput")
+        }
 
         switch self.cameraMode {
         case .video:
+            if let photoOutput = self._photoOutput, currentOutputs.contains(photoOutput) {
+                session.removeOutput(photoOutput)
+                self._photoOutput = nil
+            }
+
             break
         case .photo:
-            if let audioOutput = self._audioOutput {
-                if session.outputs.contains(where: { (audioOutput) -> Bool in
-                    return true
-                }) {
-                    session.removeOutput(audioOutput)
-                    self._audioOutput = nil
-                }
+            if let videoOutput = self._videoOutput, currentOutputs.contains(videoOutput) {
+                session.removeOutput(videoOutput)
+                self._videoOutput = nil
             }
+
+            if let audioOutput = self._audioOutput, currentOutputs.contains(audioOutput) {
+                session.removeOutput(audioOutput)
+                self._audioOutput = nil
+            }
+
             break
         case .audio:
-            if let videoOutput = self._videoOutput {
-                if session.outputs.contains(where: { (videoOutput) -> Bool in
-                    return true
-                }) {
-                    session.removeOutput(videoOutput)
-                    self._videoOutput = nil
-                }
+            if let videoOutput = self._videoOutput, currentOutputs.contains(videoOutput) {
+                session.removeOutput(videoOutput)
+                self._videoOutput = nil
             }
+
+            if let photoOutput = self._photoOutput, currentOutputs.contains(photoOutput) {
+                session.removeOutput(photoOutput)
+                self._photoOutput = nil
+            }
+
             break
         }
         

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -1119,7 +1119,7 @@ extension NextLevel {
 
     private func removeOutputs(session: AVCaptureSession) {
         guard let outputs = session.outputs as? [AVCaptureOutput] else {
-            fatalError("Expected outputs to be an array of AVCaptureOutput")
+            return
         }
 
         for output in outputs {
@@ -1133,7 +1133,7 @@ extension NextLevel {
 
     internal func removeOutputsIfNecessary(session: AVCaptureSession) {
         guard let currentOutputs = session.outputs as? [AVCaptureOutput] else {
-            fatalError("Expected outputs to be an array of AVCaptureOutput")
+            return
         }
 
         switch self.cameraMode {

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -556,6 +556,10 @@ public class NextLevel: NSObject {
 
     public var cameraMode: NextLevelCaptureMode {
         didSet {
+            guard self.cameraMode != oldValue else {
+                return
+            }
+
             self.configureSession()
             self.configureSessionDevices()
         }

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -821,7 +821,7 @@ extension NextLevel {
 
                 self.beginConfiguration()
                 self.removeInputs(session: session)
-                self.removeOutputsIfNecessary(session: session)
+                self.removeOutputs(session: session)
                 self.commitConfiguration()
                 
                 self._recordingSession = nil
@@ -1116,9 +1116,23 @@ extension NextLevel {
         return false
         
     }
+
+    private func removeOutputs(session: AVCaptureSession) {
+        guard let outputs = session.outputs as? [AVCaptureOutput] else {
+            fatalError("Expected outputs to be an array of AVCaptureOutput")
+        }
+
+        for output in outputs {
+            session.removeOutput(output)
+        }
+
+        self._videoOutput = nil
+        self._audioInput = nil
+        self._photoOutput = nil
+    }
     
     internal func removeOutputsIfNecessary(session: AVCaptureSession) {
-        
+
         switch self.cameraMode {
         case .video:
             break


### PR DESCRIPTION
As detailed in #19, inputs are not added to the AVCaptureSession when starting `NextLevel` after it has been stopped at least once.

This PR fixes the issue by clearing `_currentDevice` from within the `stop()` function.

Some changes have also been made in regards to how outputs are removed when `NextLevel` is stopped. Previously, `removeOutputsIfNecessary(session:)` was called by `stop()` to clean up the session's outputs. As I understand, this wasn't actually removing any outputs, since `removeOutputsIfNecessary(session:)` only removes outputs no longer needed for the current mode (eg. in photo mode, it will remove video/audio outputs). A `removeOutputs(session:)` function has been added to allow removing all outputs from the session where necessary. 

`removeOutputsIfNecessary(session:)` has also been renamed to `removeUnusedOutputsForCurrentCameraMode(session:)`