### PR TITLE
Nextlevel clip will hold on generated thumbnail and last frame images

### DIFF
--- a/Sources/NextLevelClip.swift
+++ b/Sources/NextLevelClip.swift
@@ -190,8 +190,8 @@ public class NextLevelClip: NSObject {
     
     internal var _asset: AVAsset?
     internal var _infoDict: [String : Any]?
-    internal weak var _thumbnailImage: UIImage?
-    internal weak var _lastFrameImage: UIImage?
+    internal var _thumbnailImage: UIImage?
+    internal var _lastFrameImage: UIImage?
     
     // MARK: - object lifecycle
     


### PR DESCRIPTION
Thumbnail and last frame images are assigned weakly to NextLevelClip objects. These image gets deallocated right after initialized.