### PR TITLE
Compression Quality

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -2096,7 +2096,7 @@ extension NextLevel {
                 
                 // add JPEG, thumbnail
                 if let photo = self.uiimage(fromPixelBuffer: customFrame),
-                    let imageData = UIImageJPEGRepresentation(photo, 0) {
+                    let imageData = UIImageJPEGRepresentation(photo, 1) {
                     
                     if photoDict == nil {
                         photoDict = [:]
@@ -2117,7 +2117,7 @@ extension NextLevel {
                 
                 // add JPEG, thumbnail
                 if let photo = self.uiimage(fromSampleBuffer: videoFrame),
-                    let imageData = UIImageJPEGRepresentation(photo, 0) {
+                    let imageData = UIImageJPEGRepresentation(photo, 1) {
                     
                     if photoDict == nil {
                         photoDict = [:]


### PR DESCRIPTION
Setting the second parameter to 0 fully compresses the image, whereas setting it to 1 preserves the image data and let's users get a better image quality from a video source.