### PR TITLE
Fix Video/Audio asset writers constantly being reset

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -3032,7 +3032,7 @@ extension NextLevel {
             // TODO: add delegate callback
         })
         
-        self._observers.append(currentDevice.observe(\.ISO, options: [.new]) { [weak self] (object, change) in
+        self._observers.append(currentDevice.observe(\.iso, options: [.new]) { [weak self] (object, change) in
             // TODO: add delegate callback
         })
         

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -69,14 +69,14 @@ public class NextLevelSession {
     /// Checks if the session is setup for recording video
     public var isVideoReady: Bool {
         get {
-            return self._videoInput?.isReadyForMoreMediaData ?? false
+            return self._videoInput != nil
         }
     }
     
     /// Checks if the session is setup for recording audio
     public var isAudioReady: Bool {
         get {
-            return self._audioInput?.isReadyForMoreMediaData ?? false
+            return self._audioInput != nil
         }
     }
 
@@ -239,9 +239,6 @@ extension NextLevelSession {
     ///   - formatDescription: sample buffer format description
     /// - Returns: True when setup completes successfully
     public func setupVideo(withSettings settings: [String : Any]?, configuration: NextLevelVideoConfiguration, formatDescription: CMFormatDescription? = nil) -> Bool {
-        guard _videoInput == nil else {
-            return true
-        }
         if let formatDescription = formatDescription {
             self._videoInput = AVAssetWriterInput(mediaType: AVMediaType.video, outputSettings: settings, sourceFormatHint: formatDescription)
         } else {
@@ -286,9 +283,6 @@ extension NextLevelSession {
     ///   - formatDescription: sample buffer format description
     /// - Returns: True when setup completes successfully
     public func setupAudio(withSettings settings: [String : Any]?, configuration: NextLevelAudioConfiguration, formatDescription: CMFormatDescription) -> Bool {
-        guard _audioInput == nil else {
-            return true
-        }
         self._audioInput = AVAssetWriterInput(mediaType: AVMediaType.audio, outputSettings: settings, sourceFormatHint: formatDescription)
         if let audioInput = self._audioInput {
             audioInput.expectsMediaDataInRealTime = true

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -239,6 +239,9 @@ extension NextLevelSession {
     ///   - formatDescription: sample buffer format description
     /// - Returns: True when setup completes successfully
     public func setupVideo(withSettings settings: [String : Any]?, configuration: NextLevelVideoConfiguration, formatDescription: CMFormatDescription? = nil) -> Bool {
+        guard _videoInput == nil else {
+            return true
+        }
         if let formatDescription = formatDescription {
             self._videoInput = AVAssetWriterInput(mediaType: AVMediaType.video, outputSettings: settings, sourceFormatHint: formatDescription)
         } else {
@@ -283,6 +286,9 @@ extension NextLevelSession {
     ///   - formatDescription: sample buffer format description
     /// - Returns: True when setup completes successfully
     public func setupAudio(withSettings settings: [String : Any]?, configuration: NextLevelAudioConfiguration, formatDescription: CMFormatDescription) -> Bool {
+        guard _audioInput == nil else {
+            return true
+        }
         self._audioInput = AVAssetWriterInput(mediaType: AVMediaType.audio, outputSettings: settings, sourceFormatHint: formatDescription)
         if let audioInput = self._audioInput {
             audioInput.expectsMediaDataInRealTime = true


### PR DESCRIPTION
There's a pretty major issue in NextLevel where the recording completely stalls because the `_audioInput` and `_videoInput` in `NextLevelSession` is constantly being reset on every frame. This causes the `isReadyForMoreMediaData` on the inputs to be false and thus skips a lot of frames. On faster phones this doesn't happen as often, but on an iPhone 5s it's impossible to record a 30 second video.

This PR simply shows that by adjusting the check in `NextLevelSession` the inputs are not constantly overwritten. I don't think this should be merged as is, because it's really just hiding the problem in the `NextLevel` class that calls the `setupAudio` and `setupVideo` methods on the session. I'm hoping you have a cleaner way to handle this