### PR TITLE
Bug. There are no virtual content (SCNNode) in a video

### DIFF
--- a/Sources/NextLevelBufferRenderer.swift
+++ b/Sources/NextLevelBufferRenderer.swift
@@ -245,9 +245,10 @@ extension NextLevelBufferRenderer {
             commandBuffer.commit()
         }
         
+        self.setupPixelBufferPoolIfNecessary(pixelBuffer, orientation: .downMirrored)
+        
         if let pixelBufferPool = self._pixelBufferPool,
-            let texture = self._texture,
-            let newPixelBuffer = self._ciContext?.createPixelBuffer(fromPixelBuffer: pixelBuffer, withOrientation: .downMirrored, pixelBufferPool: pixelBufferPool) {
+            let newPixelBuffer = self._ciContext?.createPixelBuffer(fromPixelBuffer: pixelBuffer, withOrientation: .downMirrored, pixelBufferPool: pixelBufferPool, texture: self._texture) {
             self._videoBufferOutput = newPixelBuffer
         }
         


### PR DESCRIPTION
# Pull Request

## Description

- The bug has been fixed when there are no virtual content (SCNNode) in a video

### Motivation and Context

- We need to get video with virtual content

### Screenshots

Before fix:
- ![before_fix](https://user-images.githubusercontent.com/44296595/55087279-eb1a0180-50ba-11e9-9d49-37c4d96bb213.png)

After fix:
- ![after_fix](https://user-images.githubusercontent.com/44296595/55087285-f10fe280-50ba-11e9-9d56-443830be24c2.png)

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Maintenance
