### PR TITLE
move updateVideoOutputSettings to configure session

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -972,7 +972,6 @@ extension NextLevel {
                 
                 if input.device.hasMediaType(AVMediaType.video) {
                     self.addCaptureDeviceObservers(input.device)
-                    self.updateVideoOutputSettings()
                     self._videoInput = input
                 } else {
                     self._audioInput = input
@@ -1032,6 +1031,9 @@ extension NextLevel {
             if session.canAddOutput(videoOutput) {
                 session.addOutput(videoOutput)
                 videoOutput.setSampleBufferDelegate(self, queue: self._sessionQueue)
+                
+                self.updateVideoOutputSettings()
+                
                 return true
             }
         }


### PR DESCRIPTION
The updateVideoOutputSettings function was being called after adding an input instead of when initially setting up the video output. This caused a heavy delay (approx. 45-50 frames or 1.6 seconds) on processing frames leading to camera capture lagging behind the preview screen. 

The delay occurred in between the session starting, and when the first frame was processed in the captureOutput delegate. The captureOutput delegate would start receiving the first frame late and would spend the entire session trying the catch up always staying 45-50 frames behind.

While this was less obvious, but still very present on older devices, new devices like the iPhone 11 pro really show this delay. When taking a video or taking a picture of the last video frame, this would start from about 1.6 seconds behind what was shown on the preview screen.

This can be demonstrated by taking a photo from the video right after moving the camera to a new location. The photo will be of the old location.