### PR TITLE
Fix metadata creation date

### DIFF
--- a/Sources/NextLevel+Metadata.swift
+++ b/Sources/NextLevel+Metadata.swift
@@ -102,9 +102,15 @@ extension NextLevel {
         artistItem.value = NextLevelMetadataArtist as (NSCopying & NSObjectProtocol)
         
         let creationDateItem = AVMutableMetadataItem()
-        creationDateItem.keySpace = AVMetadataKeySpace.common
-        creationDateItem.key = AVMetadataKey.commonKeyCreationDate as (NSCopying & NSObjectProtocol)
-        creationDateItem.value = Date().iso8601() as (NSCopying & NSObjectProtocol)
+        creationDateItem.keySpace = .common
+        
+        if #available(iOS 13.0, *) {
+            creationDateItem.key = AVMetadataKey.commonKeyCreationDate as NSString
+            creationDateItem.value = Date() as NSDate
+        } else {
+            creationDateItem.key = AVMetadataKey.commonKeyCreationDate as (NSCopying & NSObjectProtocol)
+            creationDateItem.value = Date().iso8601() as (NSCopying & NSObjectProtocol)
+        }
         
         return [modelItem, softwareItem, artistItem, creationDateItem]
     }


### PR DESCRIPTION
If you save video file written by NextLevel into your library it will show a date 1.1.1970

This [issue](https://stackoverflow.com/questions/57687646/avassetwriter-metadata-date-issue) suggests this might be a recent change (iOS 13)

I am not able to test on device lower the 13.0 so I just added a check for iOS version in order not to break previous versions.