### PR TITLE
Output metadata

### DIFF
--- a/Sources/NextLevel+Metadata.swift
+++ b/Sources/NextLevel+Metadata.swift
@@ -28,7 +28,6 @@ import Foundation
 import AVFoundation
 import CoreMedia
 import ImageIO
-import class CoreLocation.CLLocation
 
 extension CMSampleBuffer {
     

--- a/Sources/NextLevel+Metadata.swift
+++ b/Sources/NextLevel+Metadata.swift
@@ -28,6 +28,7 @@ import Foundation
 import AVFoundation
 import CoreMedia
 import ImageIO
+import class CoreLocation.CLLocation
 
 extension CMSampleBuffer {
     

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -165,6 +165,10 @@ public class NextLevelSession {
         }
     }
     
+    /// Specifies custom metadata that should be attached to the output file
+    public var outputMetadata: [AVMetadataItem] = []
+    
+    
     // MARK: - private instance vars
     
     internal var _identifier: UUID
@@ -312,7 +316,7 @@ extension NextLevelSession {
             self._writer = try AVAssetWriter(url: url, fileType: self.fileType)
             if let writer = self._writer {
                 writer.shouldOptimizeForNetworkUse = true
-                writer.metadata = NextLevel.assetWriterMetadata()
+                writer.metadata = NextLevel.assetWriterMetadata() + outputMetadata
                 
                 if let videoInput = self._videoInput {
                     if writer.canAdd(videoInput) {


### PR DESCRIPTION
- Add ability to attach custom metadata to the writer output
- Useful if you want to attach e.g. CLLocation at the time of recording