### PR TITLE
Audio sync - re-appending skipped audio buffer

### DIFF
--- a/Sources/NextLevel+Metadata.swift
+++ b/Sources/NextLevel+Metadata.swift
@@ -28,7 +28,6 @@ import Foundation
 import AVFoundation
 import CoreMedia
 import ImageIO
-import class CoreLocation.CLLocation
 
 extension CMSampleBuffer {
     

--- a/Sources/NextLevel+Metadata.swift
+++ b/Sources/NextLevel+Metadata.swift
@@ -28,6 +28,7 @@ import Foundation
 import AVFoundation
 import CoreMedia
 import ImageIO
+import class CoreLocation.CLLocation
 
 extension CMSampleBuffer {
     

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -200,6 +200,8 @@ public class NextLevelSession {
     internal var _lastAudioTimestamp: CMTime = CMTime.invalid
     internal var _lastVideoTimestamp: CMTime = CMTime.invalid
     
+    internal var _skippedAudioBuffers:[CMSampleBuffer] = []
+    
     private let NextLevelSessionAudioQueueIdentifier = "engineering.NextLevel.session.audioQueue"
     private let NextLevelSessionQueueIdentifier = "engineering.NextLevel.sessionQueue"
     private let NextLevelSessionSpecificKey = DispatchSpecificKey<()>()
@@ -467,29 +469,40 @@ extension NextLevelSession {
     ///   - completionHandler: Handler when a frame appending operation completes or fails
     public func appendAudio(withSampleBuffer sampleBuffer: CMSampleBuffer, completionHandler: @escaping NextLevelSessionAppendSampleBufferCompletionHandler) {
         self.startSessionIfNecessary(timestamp: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
-        
-        let duration = CMSampleBufferGetDuration(sampleBuffer)
-        if let adjustedBuffer = CMSampleBuffer.createSampleBuffer(fromSampleBuffer: sampleBuffer, withTimeOffset: self._timeOffset, duration: duration) {
-            let presentationTimestamp = CMSampleBufferGetPresentationTimeStamp(adjustedBuffer)
-            let lastTimestamp = CMTimeAdd(presentationTimestamp, duration)
+        self._audioQueue.async {
             
-            self._audioQueue.async {
-                if let audioInput = self._audioInput,
-                    audioInput.isReadyForMoreMediaData,
-                    audioInput.append(adjustedBuffer) {
-                    self._lastAudioTimestamp = lastTimestamp
+            var hasFailed = false
+            
+            let buffers = self._skippedAudioBuffers + [sampleBuffer]
+            self._skippedAudioBuffers = []
+            var failedBuffers: [CMSampleBuffer] = []
+            
+            buffers.forEach { buffer in
+                let duration = CMSampleBufferGetDuration(buffer)
+                if let adjustedBuffer = CMSampleBuffer.createSampleBuffer(fromSampleBuffer: buffer, withTimeOffset: self._timeOffset, duration: duration) {
+                    let presentationTimestamp = CMSampleBufferGetPresentationTimeStamp(adjustedBuffer)
+                    let lastTimestamp = CMTimeAdd(presentationTimestamp, duration)
                     
-                    if !self.currentClipHasVideo {
-                        self._currentClipDuration = CMTimeSubtract(lastTimestamp, self._startTimestamp)
+                    if let audioInput = self._audioInput,
+                        audioInput.isReadyForMoreMediaData,
+                        audioInput.append(adjustedBuffer) {
+                        self._lastAudioTimestamp = lastTimestamp
+                        
+                        if !self.currentClipHasVideo {
+                            self._currentClipDuration = CMTimeSubtract(lastTimestamp, self._startTimestamp)
+                        }
+                        
+                        self._currentClipHasAudio = true
+                        
+                    } else {
+                        failedBuffers.append(buffer)
+                        hasFailed = true
                     }
-                    
-                    self._currentClipHasAudio = true
-                    
-                    completionHandler(true)
-                } else {
-                    completionHandler(false)
                 }
             }
+            
+            self._skippedAudioBuffers = failedBuffers
+            completionHandler(!hasFailed)
         }
     }
     
@@ -500,7 +513,7 @@ extension NextLevelSession {
             self._videoInput = nil
             self._audioInput = nil
             self._pixelBufferAdapter = nil
-            
+            self._skippedAudioBuffers = []
             self._videoConfiguration = nil
             self._audioConfiguration = nil
         }

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -165,6 +165,10 @@ public class NextLevelSession {
         }
     }
     
+    /// Specifies custom metadata that should be attached to the output file
+    public var outputMetadata: [AVMetadataItem] = []
+    
+    
     // MARK: - private instance vars
     
     internal var _identifier: UUID
@@ -312,7 +316,7 @@ extension NextLevelSession {
             self._writer = try AVAssetWriter(url: url, fileType: self.fileType)
             if let writer = self._writer {
                 writer.shouldOptimizeForNetworkUse = true
-                writer.metadata = NextLevel.assetWriterMetadata()
+                writer.metadata = NextLevel.assetWriterMetadata() + outputMetadata
                 
                 if let videoInput = self._videoInput {
                     if writer.canAdd(videoInput) {

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -165,10 +165,6 @@ public class NextLevelSession {
         }
     }
     
-    /// Specifies custom metadata that should be attached to the output file
-    public var outputMetadata: [AVMetadataItem] = []
-    
-    
     // MARK: - private instance vars
     
     internal var _identifier: UUID
@@ -318,7 +314,7 @@ extension NextLevelSession {
             self._writer = try AVAssetWriter(url: url, fileType: self.fileType)
             if let writer = self._writer {
                 writer.shouldOptimizeForNetworkUse = true
-                writer.metadata = NextLevel.assetWriterMetadata() + outputMetadata
+                writer.metadata = NextLevel.assetWriterMetadata()
                 
                 if let videoInput = self._videoInput {
                     if writer.canAdd(videoInput) {


### PR DESCRIPTION
I have been having problems with audio falling out of sync because of multiple audio buffers being skipped frequently. I am not sure what is the exact cause of the frames dropping, since it's hard to debug, but I rewritten fix from this fork: https://github.com/shaharyakir/NextLevel, which simply stores buffers that failed to attach and tries to re-append them together with the next frame.

It seems it solves most of the issues with audio sync for me. Is there something I am missing or can this be merged into master? Would this make sense to do also for video buffers? While video frame drops are more rare, it still does happen at times.