### PR TITLE
Update video output settings after configuring devices

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -656,6 +656,7 @@ extension NextLevel {
                 
                 self.configureSession()
                 self.configureSessionDevices()
+                self.updateVideoOutputSettings()
                 self.configureMetadataObjects()
                 self.updateVideoOrientation()
                 
@@ -698,6 +699,7 @@ extension NextLevel {
                 self.beginConfiguration()
                 self.configureSession()
                 self.configureSessionDevices()
+                self.updateVideoOutputSettings()
                 self.updateVideoOrientation()
                 self.commitConfiguration()
             }


### PR DESCRIPTION
Default and preconfigured `videoStabilizationMode` is never set cause `updateVideoOutputSettings` method is always called before devices are connected to capture session. So the only way to enable stabilization right now is to set it after starting recording session:
```
NextLevel.shared.start()
NextLevel.shared.videoStabilizationMode = .auto
```
I added call of `updateVideoOutputSettings` right after configuring of devices, so i can set current `videoStabilizationMode` properly.