### PR TITLE
1080p support and delegate notifications as exposure duration change

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -3169,12 +3169,15 @@ extension NextLevel {
             }
         })
 
-        self._observers.append(currentDevice.observe(\.exposureDuration, options: [.new]) { [weak self] _, _ in
-            guard let _ = self else {
-                return
-            }
+        self._observers.append(currentDevice.observe(\.exposureDuration, options: [.new]) { [weak self] _, change in
+			guard let strongSelf = self,
+				  let exposureDuration = change.newValue else {
+				return
+			}
 
-            // TODO: add delegate callback
+			DispatchQueue.main.async {
+				strongSelf.deviceDelegate?.nextLevel(strongSelf, didChangeExposureDuration: exposureDuration)
+			}
         })
 
         self._observers.append(currentDevice.observe(\.iso, options: [.new]) { [weak self] _, _ in

--- a/Sources/NextLevelConfiguration.swift
+++ b/Sources/NextLevelConfiguration.swift
@@ -218,6 +218,9 @@ public class NextLevelVideoConfiguration: NextLevelConfiguration {
     /// Maximum recording duration, when set, session finishes automatically
     public var maximumCaptureDuration: CMTime?
 
+	// Video dimensions evenly dividable by this number of pixeld
+	public var sizeDivisibleBy: Int? = 16
+
     // MARK: - object lifecycle
 
     override public init() {
@@ -280,7 +283,9 @@ public class NextLevelVideoConfiguration: NextLevelConfiguration {
             config[AVVideoHeightKey] = NSNumber(integerLiteral: Int(height))
         }
 
-        config = self.update(config: config)
+		if let sizeDivisibleBy = sizeDivisibleBy {
+			config = adjustConfigurationDimensions(config: config, withSizeValuesDivisibleBy: sizeDivisibleBy)
+		}
 
         config[AVVideoCodecKey] = self.codec
         config[AVVideoScalingModeKey] = self.scalingMode
@@ -309,7 +314,7 @@ public class NextLevelVideoConfiguration: NextLevelConfiguration {
     ///   - config: Input configuration dictionary
     ///   - divisibleBy: Divisor
     /// - Returns: Configuration with appropriately divided sizes
-    private func update(config: [String: Any], withSizeValuesDivisibleBy divisibleBy: Int = 16) -> [String: Any] {
+    private func adjustConfigurationDimensions(config: [String: Any], withSizeValuesDivisibleBy divisibleBy: Int = 16) -> [String: Any] {
         var config = config
 
         if let width = config[AVVideoWidthKey] as? Int {

--- a/Sources/NextLevelProtocols.swift
+++ b/Sources/NextLevelProtocols.swift
@@ -104,10 +104,19 @@ public protocol NextLevelDeviceDelegate: AnyObject {
 
     func nextLevelWillChangeExposure(_ nextLevel: NextLevel)
     func nextLevelDidChangeExposure(_ nextLevel: NextLevel)
+	func nextLevel(_ nextLevel: NextLevel, didChangeExposureDuration exposureDuration: CMTime)
 
     func nextLevelWillChangeWhiteBalance(_ nextLevel: NextLevel)
     func nextLevelDidChangeWhiteBalance(_ nextLevel: NextLevel)
 
+}
+
+public extension NextLevelDeviceDelegate {
+
+	// Empty default implementations of recently added protocol methods, to make them optional and not break existing code.
+
+	func nextLevel(_ nextLevel: NextLevel, didChangeExposureDuration exposureDuration: CMTime) {
+	}
 }
 
 // MARK: - NextLevelFlashAndTorchDelegate


### PR DESCRIPTION
Made it possible to alter block dimensions used when adjusting screen size for optimal compression. Previously it was not possible to record 1080p videos, they got a height of 1072 pixels. Now it can be done by assigning sizeDivisibleBy to nil, 4 or 8.