### PR TITLE
Possible to overload how current device orientation is fetched.

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -1347,7 +1347,7 @@ extension NextLevel {
         }
 
         var didChangeOrientation = false
-        let currentOrientation = AVCaptureVideoOrientation.avorientationFromUIDeviceOrientation(UIDevice.current.orientation)
+		let currentOrientation = self.deviceDelegate?.nextLevelCurrentDeviceOrientation?() ?? AVCaptureVideoOrientation.avorientationFromUIDeviceOrientation(UIDevice.current.orientation)
 
         if let previewConnection = self.previewLayer.connection {
             if previewConnection.isVideoOrientationSupported && previewConnection.videoOrientation != currentOrientation {

--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -1787,7 +1787,7 @@ extension NextLevel {
     /// - Parameter duration: The exposure duration in seconds.
     /// - Parameter durationPower: Larger power values will increase the sensitivity at shorter durations.
     /// - Parameter minDurationRangeLimit: Minimum limitation for duration.
-    public func expose(withDuration duration: Double, durationPower: Double = 5, minDurationRangeLimit: Double = (1.0 / 1000.0)) {
+    public func expose(withDuration duration: Double, durationPower: Double = 5, minDurationRangeLimit: Double = (1.0 / 1000.0), completionHandler: ((CMTime) -> Void)? = nil) {
         guard let device = self._currentDevice,
             !device.isAdjustingExposure
             else {
@@ -1806,7 +1806,7 @@ extension NextLevel {
             try device.lockForConfiguration()
 
 			if device.isExposureModeSupported(.custom) {
-				device.setExposureModeCustom(duration: CMTimeMakeWithSeconds( newDurationSeconds, preferredTimescale: 1000*1000*1000 ), iso: AVCaptureDevice.currentISO, completionHandler: nil)
+				device.setExposureModeCustom(duration: CMTimeMakeWithSeconds( newDurationSeconds, preferredTimescale: 1000*1000*1000 ), iso: AVCaptureDevice.currentISO, completionHandler: completionHandler)
 			}
 
             device.unlockForConfiguration()

--- a/Sources/NextLevelProtocols.swift
+++ b/Sources/NextLevelProtocols.swift
@@ -87,6 +87,7 @@ public protocol NextLevelPreviewDelegate: AnyObject {
 public protocol NextLevelDeviceDelegate: AnyObject {
 
     // position, orientation
+	var nextLevelCurrentDeviceOrientation: (() -> AVCaptureVideoOrientation)? { get }
     func nextLevelDevicePositionWillChange(_ nextLevel: NextLevel)
     func nextLevelDevicePositionDidChange(_ nextLevel: NextLevel)
     func nextLevel(_ nextLevel: NextLevel, didChangeDeviceOrientation deviceOrientation: NextLevelDeviceOrientation)
@@ -114,6 +115,8 @@ public protocol NextLevelDeviceDelegate: AnyObject {
 public extension NextLevelDeviceDelegate {
 
 	// Empty default implementations of recently added protocol methods, to make them optional and not break existing code.
+
+	var nextLevelCurrentDeviceOrientation: (() -> AVCaptureVideoOrientation)? { nil }
 
 	func nextLevel(_ nextLevel: NextLevel, didChangeExposureDuration exposureDuration: CMTime) {
 	}


### PR DESCRIPTION
Using the window scene is the preferred way nowadays.