### PR TITLE
Avoid thread race

### DIFF
--- a/Sources/NextLevel.swift
+++ b/Sources/NextLevel.swift
@@ -322,8 +322,10 @@ public class NextLevel: NSObject {
     /// The current orientation of the device.
     public var deviceOrientation: NextLevelDeviceOrientation = .portrait {
         didSet {
-            self.automaticallyUpdatesDeviceOrientation = false
-            self.updateVideoOrientation()
+            automaticallyUpdatesDeviceOrientation = false
+			_sessionQueue.sync {
+				updateVideoOrientation()
+			}
         }
     }
 


### PR DESCRIPTION
Could for instance happen if device orientation was assigned by an external thread while capture mode was changed.